### PR TITLE
Update common to use tags for the roles

### DIFF
--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -18,21 +18,21 @@
   gather_facts: True
 
   roles:
-  - { role: etc_services }
-  - { role: auth }
-  - { role: apt, tags: apt }
-  - { role: ferm }
-  - { role: pki }
-  - { role: monkeysphere }
-  - { role: sshd, tags: sshd }
-  - { role: interfaces, tags: interfaces }
-  - { role: console }
-  - { role: postfix, tags: postfix }
-  - { role: rsyslog }
-  - { role: tcpwrappers }
-  - { role: users, tags: users }
-  - { role: sshkeys, tags: sshkeys }
-  - { role: directories }
-  - { role: githost }
-  - { role: boxbackup, tags: boxbackup }
+    - { role: etc_services, tags: etc_services }
+    - { role: auth, tags: auth }
+    - { role: apt, tags: apt }
+    - { role: ferm, tags: ferm }
+    - { role: pki, tags: pki }
+    - { role: monkeysphere, tags: monkeysphere }
+    - { role: sshd, tags: sshd }
+    - { role: interfaces, tags: interfaces }
+    - { role: console, tags: console }
+    - { role: postfix, tags: postfix }
+    - { role: rsyslog, tags: rsyslog }
+    - { role: tcpwrappers, tags: tcpwrappers }
+    - { role: users, tags: users }
+    - { role: sshkeys, tags: sshkeys }
+    - { role: directories, tags: directories }
+    - { role: githost, tags: githost }
+    - { role: boxbackup, tags: boxbackup }
 

--- a/playbooks/roles/auth/tasks/main.yml
+++ b/playbooks/roles/auth/tasks/main.yml
@@ -4,9 +4,6 @@
   apt: pkg={{ item }} state=latest install_recommends=no
   with_items:
     - sudo
-  tags:
-    - auth
-    - packages
 
 - name: Ensure common system groups exist
   group: name={{ item }} system=yes state=present
@@ -15,24 +12,16 @@
     - webadmins
     - sshusers
     - sftponly
-  tags:
-    - auth
 
 - name: Create administrator accounts
   user: name={{ item }} groups=admins,webadmins state=present append=yes
   with_items:
     - ${auth_admin_accounts}
   when: auth_admin_accounts is defined
-  tags:
-    - auth
 
 - name: Ensure members of group 'admins' can su without password
   lineinfile: dest=/etc/pam.d/su state=present regexp='^(.*)auth\s+sufficient\s+pam_wheel.so\s+trust' line='auth sufficient pam_wheel.so trust group=admins'
-  tags:
-    - auth
 
 - name: Ensure members of group 'admins' can sudo without password
   lineinfile: "dest=/etc/sudoers.d/admins state=present create=yes owner=root group=root mode=0440 regexp='^%admins' line='%admins ALL = (ALL:ALL) NOPASSWD: SETENV: ALL'"
-  tags:
-    - auth
 

--- a/playbooks/roles/console/tasks/main.yml
+++ b/playbooks/roles/console/tasks/main.yml
@@ -5,31 +5,20 @@
   with_items:
     - ${console_packages}
   when: console_packages is defined
-  tags:
-    - console
-    - packages
 
 - name: Enable serial console
   lineinfile: dest=/etc/inittab regexp='^{{ console_serial }}' state=present line='{{ console_serial }}'
   when: console_serial is defined and console_serial
   notify: Reload init
-  tags:
-    - console
 
 - name: Disable serial console
   lineinfile: dest=/etc/inittab regexp='^{{ console_serial }}' state=absent
   when: console_serial is defined and console_serial == False
   notify: Reload init
-  tags:
-    - console
 
 - name: Configure /etc/issue
   template: src=etc/issue.j2 dest=/etc/issue owner=root group=root mode=0644
-  tags:
-    - console
 
 - name: Configure /etc/motd
   template: src=etc/motd.j2 dest=/etc/motd owner=root group=root mode=0644
-  tags:
-    - console
 

--- a/playbooks/roles/directories/tasks/main.yml
+++ b/playbooks/roles/directories/tasks/main.yml
@@ -5,6 +5,4 @@
   with_items:
     - ${directories_list}
   when: directories_list is defined and directories_list and item.path is defined and item.path
-  tags:
-    - directories
 

--- a/playbooks/roles/etc_services/tasks/main.yml
+++ b/playbooks/roles/etc_services/tasks/main.yml
@@ -2,29 +2,23 @@
 
 - name: Make sure /etc/services.d directory exists
   file: path=/etc/services.d state=directory owner=root group=root mode=0755
-  tags: etc_services
 
 - name: Create /etc/services.d/00_ansible
   template: src=etc/services.d/00_ansible.j2 dest=/etc/services.d/00_ansible owner=root group=root mode=0644
-  tags: etc_services
 
 - name: Divert original /etc/services
   command: dpkg-divert --quiet --local --divert {{ etc_services_diversion }} --rename /etc/services creates={{ etc_services_diversion }}
   when: etc_services is defined and etc_services
-  tags: etc_services
 
 - name: Assemble /etc/services.d
   assemble: src=/etc/services.d dest=/etc/services backup=no owner=root group=root mode=0644
   when: etc_services is defined and etc_services
-  tags: etc_services
 
 - name: Move current /etc/services out of the way before reversion
   command: rm -f /etc/services removes={{ etc_services_diversion }}
   when: etc_services is undefined or etc_services is defined and etc_services == False
-  tags: etc_services
 
 - name: Remove diversion of /etc/services
   command: dpkg-divert --quiet --local --rename --remove /etc/services removes={{ etc_services_diversion }}
   when: etc_services is undefined or etc_services is defined and etc_services == False
-  tags: etc_services
 

--- a/playbooks/roles/ferm/tasks/main.yml
+++ b/playbooks/roles/ferm/tasks/main.yml
@@ -2,41 +2,25 @@
 
 - name: Ensure ferm is installed
   apt: pkg=ferm state=latest install_recommends=no
-  tags:
-    - ferm
-    - network
-    - packages
 
 - name: Create configuration directories
   file: path={{ item }} state=directory owner=root group=root mode=0750
   with_items:
     - '/etc/ferm/ferm.d'
     - '/etc/ferm/filter-input.d'
-  tags:
-    - ferm
-    - network
 
 - name: Apply firewall configuration
   template: src={{ item }}.j2 dest=/{{ item }} owner=root group=root mode=0644
   with_items: [ 'etc/default/ferm', 'etc/ferm/ferm.conf' ]
   notify: Restart ferm
-  tags:
-    - ferm
-    - network
 
 - name: Apply iptables rules if ferm is enabled
   command: ferm --slow /etc/ferm/ferm.conf
   changed_when: False
   when: ferm is defined and ferm
-  tags:
-    - ferm
-    - network
 
 - name: Clear iptables rules if ferm is disabled
   command: ferm --flush /etc/ferm/ferm.conf
   changed_when: False
   when: ferm is undefined or ferm is defined and ferm == False
-  tags:
-    - ferm
-    - network
 

--- a/playbooks/roles/githost/tasks/main.yml
+++ b/playbooks/roles/githost/tasks/main.yml
@@ -3,31 +3,21 @@
 - name: Create git user
   user: name={{ githost_user }} state=present home={{ githost_home }} shell=/usr/bin/git-shell groups=sshusers append=yes
   when: githost is defined and githost == True
-  tags:
-    - githost
 
 - name: Secure git home
   file: path={{ githost_home }} state=directory mode=0700
   when: githost is defined and githost == True
-  tags:
-    - githost
 
 - name: Create git-shell command directory
   file: path={{ githost_home }}/git-shell-commands state=directory owner=root group=root mode=0755
   when: githost is defined and githost == True
-  tags:
-    - githost
 
 - name: Install git-shell commands
   template: src=srv/git/git-shell-commands/{{ item }}.j2 dest={{ githost_home }}/git-shell-commands/{{ item }} owner=root group=root mode=0755
   with_items: [ 'help', 'list', 'create', 'addkey' ]
   when: githost is defined and githost == True
-  tags:
-    - githost
 
 - name: Setup SSH key of current user for git access
   authorized_key: user={{ githost_user }} key="{{ lookup('file','~/.ssh/id_rsa.pub') }}" state=present key_options='no-agent-forwarding,no-port-forwarding,no-X11-forwarding'
   when: githost is defined and githost == True
-  tags:
-    - githost
 

--- a/playbooks/roles/monkeysphere/tasks/authentication_setup.yml
+++ b/playbooks/roles/monkeysphere/tasks/authentication_setup.yml
@@ -4,7 +4,6 @@
   shell: monkeysphere-authentication diagnostics | grep "No Identity Certifiers found" || true
   register: monkeysphere_authentication_status
   changed_when: monkeysphere_authentication_status.rc != 0
-  tags: monkeysphere
 
 - name: Add default identity certifiers
   shell: yes | monkeysphere-authentication add-identity-certifier {{ item }}
@@ -13,11 +12,9 @@
         monkeysphere_default_identity_certifiers and
         monkeysphere_authentication_status is defined and
         monkeysphere_authentication_status.stdout.startswith('! No Identity Certifiers found!')
-  tags: monkeysphere
 
 - name: Configure automatic key update in cron
   cron: name="monkeysphere update user keys" minute={{ monkeysphere_update_minute }}
         user="root" job="/usr/sbin/monkeysphere-authentication update-users"
         cron_file=monkeysphere-authentication
-  tags: monkeysphere
 

--- a/playbooks/roles/monkeysphere/tasks/host_setup.yml
+++ b/playbooks/roles/monkeysphere/tasks/host_setup.yml
@@ -4,13 +4,11 @@
   command: monkeysphere-host diagnostics
   register: monkeysphere_host_status
   changed_when: monkeysphere_host_status.rc != 0
-  tags: monkeysphere
 
 - name: Import SSH host key
   command: monkeysphere-host import-key /etc/ssh/ssh_host_rsa_key ssh://{{ ansible_fqdn }}
   when: monkeysphere_host_status is defined and
         monkeysphere_host_status.stdout.startswith('No host OpenPGP certificates file found!')
-  tags: monkeysphere
 
   # Publish host key at the time of first generation
 - name: Publish GPG host certificate to Web of Trust
@@ -19,5 +17,4 @@
         monkeysphere_autopublish and
         monkeysphere_host_status is defined and
         monkeysphere_host_status.stdout.startswith('No host OpenPGP certificates file found!')
-  tags: monkeysphere
 

--- a/playbooks/roles/monkeysphere/tasks/install.yml
+++ b/playbooks/roles/monkeysphere/tasks/install.yml
@@ -2,7 +2,6 @@
 
 - name: Install monkeysphere packages
   apt: pkg=monkeysphere state=latest install_recommends=no
-  tags: [ monkeysphere, packages ]
 
 - name: Update monkeysphere configuration
   template: src={{ item }}.j2 dest=/{{ item }} owner=root group=root mode=0644
@@ -10,9 +9,7 @@
     - 'etc/monkeysphere/monkeysphere.conf'
     - 'etc/monkeysphere/monkeysphere-host.conf'
     - 'etc/monkeysphere/monkeysphere-authentication.conf'
-  tags: monkeysphere
 
 - name: Create system-wide GPG userids directory
   file: path=/etc/monkeysphere/authorized_user_ids state=directory owner=root group=root mode=0751
-  tags: monkeysphere
 

--- a/playbooks/roles/pki/tasks/pki.yml
+++ b/playbooks/roles/pki/tasks/pki.yml
@@ -3,24 +3,20 @@
 - name: Ensure OpenSSL support is installed
   apt: pkg={{ item }} state=latest install_recommends=no
   with_items: [ 'openssl', 'openssl-blacklist', 'ca-certificates', 'ssl-cert' ]
-  tags: [ 'pki' ]
 
 - name: Manage certificate directory structure
   file: path={{ pki_path }}/{{ item }} state=directory owner=root group=root mode=0755
   with_items: [ 'host/selfsigned', 'host/signed', 'host/req', 'host/csr', 'host/crl', 'ca/certs', 'ca/crl', 'wildcard/certs', 'wildcard/crl' ]
-  tags: [ 'pki' ]
 
 - name: Manage private directory structure
   file: path={{ pki_path }}/{{ item }} state=directory owner=root group={{ pki_private_group }} mode=0710
   with_items: [ 'host/private', 'wildcard/private' ]
-  tags: [ 'pki' ]
 
 - name: Create local directory structure on Ansible controller
   local_action: file path={{ secret }}/pki/{{ item }} state=directory
   with_items: [ 'ca/certs', 'ca/crl', 'wildcard/certs', 'wildcard/crl', 'wildcard/private' ]
   sudo: no
   when: secret is defined and secret
-  tags: [ 'pki' ]
 
 - name: Configure certificate request template
   template: src=srv/pki/host/req/openssl.cnf.j2
@@ -30,7 +26,6 @@
     - ${pki_default_certificate}
     - ${pki_host_certificates}
   when: item.cn is defined and item.cn
-  tags: [ 'pki' ]
 
 - name: Generate certificate keys
   command: openssl genrsa -out {{ pki_path }}/host/private/{{ item.cn }}.key {{ pki_bits }}
@@ -39,7 +34,6 @@
     - ${pki_default_certificate}
     - ${pki_host_certificates}
   when: item.cn is defined and item.cn
-  tags: [ 'pki' ]
 
 - name: Set correct permissions for certificate keys
   file: path={{ pki_path }}/host/private/{{ item.cn }}.key state=file owner=root group={{ pki_private_group }} mode=0440
@@ -47,7 +41,6 @@
     - ${pki_default_certificate}
     - ${pki_host_certificates}
   when: item.cn is defined and item.cn
-  tags: [ 'pki' ]
 
 - name: Create certificate requests
   command: openssl req -new -utf8 -config {{ pki_path }}/host/req/{{ item.cn }}.cnf -out {{ pki_path }}/host/csr/{{ item.cn }}.csr
@@ -56,7 +49,6 @@
     - ${pki_default_certificate}
     - ${pki_host_certificates}
   when: item.cn is defined and item.cn
-  tags: [ 'pki' ]
 
 - name: Create self-signed certificates
   command: openssl x509 -req -extfile {{ pki_path }}/host/req/{{ item.cn }}.cnf -extensions v3_ca -in {{ pki_path }}/host/csr/{{ item.cn }}.csr -out {{ pki_path }}/host/selfsigned/{{ item.cn }}.crt -signkey {{ pki_path }}/host/private/{{ item.cn }}.key -days {{ pki_selfsign_days }}
@@ -65,7 +57,6 @@
     - ${pki_default_certificate}
     - ${pki_host_certificates}
   when: item.cn is defined and item.cn
-  tags: [ 'pki' ]
 
 - name: Upload certificate requests
   fetch: src={{ pki_path }}/host/csr/{{ item.cn }}.csr
@@ -75,7 +66,6 @@
     - ${pki_default_certificate}
     - ${pki_host_certificates}
   when: item.cn is defined and item.cn and secret is defined and secret
-  tags: [ 'pki' ]
 
 - name: Download CA certificates
   copy: src={{ secret }}/pki/ca/{{ item }}/
@@ -84,7 +74,6 @@
   with_items: [ 'certs', 'crl' ]
   when: secret is defined and secret
   notify: Update ca-certificates
-  tags: [ 'pki' ]
 
 - name: Download Wildcard certificates
   copy: src={{ secret }}/pki/wildcard/{{ item }}/
@@ -93,14 +82,12 @@
   with_items: [ 'certs', 'crl' ]
   when: secret is defined and secret and pki_wildcard is defined and pki_wildcard
   notify: Update ca-certificates
-  tags: [ 'pki' ]
 
 - name: Download Wildcard private keys
   copy: src={{ secret }}/pki/wildcard/private/
         dest={{ pki_path }}/wildcard/private/
         owner=root group={{ pki_private_group }} mode=0440
   when: secret is defined and secret and pki_wildcard is defined and pki_wildcard
-  tags: [ 'pki' ]
 
   # Without this Ansible gives fatal error on next task
 - name: Create local certificate directory on Ansible controller
@@ -108,7 +95,6 @@
   with_items: [ 'signed', 'crl' ]
   sudo: no
   when: secret is defined and secret
-  tags: [ 'pki' ]
 
 - name: Download host certificates
   copy: src={{ secret }}/pki/hosts/{{ ansible_fqdn }}/{{ item }}/
@@ -116,14 +102,11 @@
         owner=root group=root mode=0644
   with_items: [ 'signed', 'crl' ]
   when: secret is defined and secret
-  tags: [ 'pki' ]
 
 - name: Symlink CA certificates
   shell: find {{ pki_path }}/ca/certs -name '*.crt' -type f -exec ln -s {} /usr/local/share/ca-certificates/ \;
   changed_when: False
-  tags: [ 'pki' ]
 
 - name: Flush handlers if required
   meta: flush_handlers
-  tags: [ 'pki' ]
 

--- a/playbooks/roles/rsyslog/tasks/main.yml
+++ b/playbooks/roles/rsyslog/tasks/main.yml
@@ -3,6 +3,4 @@
 - name: Send log messages from cron to /var/log/cron.log
   template: src=etc/rsyslog.d/cron.conf.j2 dest=/etc/rsyslog.d/cron.conf owner=root group=root backup=no
   notify: Restart rsyslogd
-  tags:
-    - rsyslog
 

--- a/playbooks/roles/tcpwrappers/tasks/denyhosts.yml
+++ b/playbooks/roles/tcpwrappers/tasks/denyhosts.yml
@@ -3,22 +3,13 @@
 - name: Install denyhosts if enabled
   apt: pkg=denyhosts state=latest install_recommends=no
   when: tcpwrappers_denyhosts.enable
-  tags:
-    - tcpwrappers
-    - network
 
 - name: Remove denyhosts if disabled
   apt: pkg=denyhosts state=absent purge=yes
   when: not tcpwrappers_denyhosts.enable
-  tags:
-    - tcpwrappers
-    - network
 
 - name: Setup /etc/denyhosts.conf if denyhosts is enabled
   template: src=etc/denyhosts.conf.j2 dest=/etc/denyhosts.conf owner=root group=root mode=0640
   notify: Restart denyhosts
   when: tcpwrappers_denyhosts.enable
-  tags:
-    - tcpwrappers
-    - network
 

--- a/playbooks/roles/tcpwrappers/tasks/hosts.allow.yml
+++ b/playbooks/roles/tcpwrappers/tasks/hosts.allow.yml
@@ -2,20 +2,10 @@
 
 - name: Make sure /etc/hosts.allow.d directory exists
   file: path=/etc/hosts.allow.d state=directory owner=root group=root mode=0755
-  tags:
-    - tcpwrappers
-    - network
 
 - name: Create /etc/hosts.allow.d/00_ansible
   template: src=etc/hosts.allow.d/00_ansible.j2 dest=/etc/hosts.allow.d/00_ansible owner=root group=root mode=0644
-  tags:
-    - tcpwrappers
-    - network
 
 - name: Assemble hosts.allow.d
   assemble: src=/etc/hosts.allow.d dest=/etc/hosts.allow backup=no owner=root group=root mode=0644
-  tags:
-    - tcpwrappers
-    - network
-
 

--- a/playbooks/roles/tcpwrappers/tasks/hosts.deny.yml
+++ b/playbooks/roles/tcpwrappers/tasks/hosts.deny.yml
@@ -3,30 +3,18 @@
 - name: Check if denyhosts is installed
   stat: path=/usr/sbin/denyhosts
   register: installed_denyhosts
-  tags:
-    - tcpwrappers
-    - network
 
 - name: denyhosts not installed - block everything
   lineinfile: "dest=/etc/hosts.deny regexp='^ALL: ALL' line='ALL: ALL' state=present"
   when: installed_denyhosts.stat.exists is defined and installed_denyhosts.stat.exists == False
-  tags:
-    - tcpwrappers
-    - network
 
 - name: denyhosts installed - unblock everything
   lineinfile: "dest=/etc/hosts.deny regexp='^ALL: ALL' state=absent"
   when: installed_denyhosts.stat.exists is defined and installed_denyhosts.stat.exists == True
-  tags:
-    - tcpwrappers
-    - network
 
 - name: Deny access from custom list if denyhosts is installed
   lineinfile: "dest=/etc/hosts.deny regexp='{{ item }}' insertafter='# ALL: PARANOID' line='{{ item }}' state={{ tcpwrappers_deny_custom_state }}"
   with_items:
     - ${tcpwrappers_deny_custom}
   when: tcpwrappers_deny_custom is defined and installed_denyhosts.stat.exists is defined and installed_denyhosts.stat.exists == True
-  tags:
-    - tcpwrappers
-    - network
 


### PR DESCRIPTION
This should allow you to run a set of roles based on the tags specified.  

I marked the roles with other tags with a comment because I am not positive on the behavior.  Take the auth role for example, the first action is `Install auth-related packages`.  It should be run on the `packages` tag and the `auth` tag.

My testing showed that  `$ ./vagrant.sh --tags=auth` would execute the action as would  `$ ./vagrant.sh --tags=packages`.  However `--tags=packages` would not execute the other actions in the `auth` role.

That is the desired behavior correct?

When it comes time to merge this, I can squash it into one commit for readability.
