### PR TITLE
Remove ssh-keyscan task from gitlab role

### DIFF
--- a/playbooks/roles/gitlab/tasks/configure_gitlab-shell.yml
+++ b/playbooks/roles/gitlab/tasks/configure_gitlab-shell.yml
@@ -61,8 +61,4 @@
   sudo_user: '{{ gitlab_user }}'
   when: gitlab_register_shell_checkout is defined and gitlab_register_shell_checkout.changed == True
 
-- name: Add GitLab host to SSH known hosts
-  shell: ssh-keyscan -t rsa,ecdsa -H {{ gitlab_domain }} > {{ gitlab_home }}/.ssh/known_hosts
-  sudo_user: '{{ gitlab_user }}'
-  when: gitlab_register_shell_checkout is defined and gitlab_register_shell_checkout.changed == True
 


### PR DESCRIPTION
gitlab-shell does not require SSH access to GitLab host on localhost.
