### PR TITLE
Update unattended-upgrades configuration in 'apt'

### DIFF
--- a/playbooks/roles/apt/defaults/main.yml
+++ b/playbooks/roles/apt/defaults/main.yml
@@ -13,14 +13,27 @@ apt: True
 apt_codename: '{{ ansible_lsb.codename }}'
 apt_codename_backports: '{{ apt_codename }}-backports'
 
+# Send mail notifications from APT to these email addresses
+apt_mail_notifications: [ 'root' ]
+
+
+# ---- unattended-upgrades ----
+
 # Enable unattended-upgrades
 apt_unattended_upgrades: True
 
-# Install upgradeable packages automatically (choices: 1,0)
-apt_unattended_upgrades_auto: "1"
+# Do not automatically upgrade these packages
+apt_unattended_upgrades_blacklist: [ 'vim', 'libc6' ]
 
-# Send mail from unattended-upgrades to these email addresses
-apt_unattended_upgrades_mail: [ 'root' ]
+# If True, send mail notifications about all performed automatic upgrades
+# If False, send mail notifications only on errors
+apt_unattended_upgrades_notify_always: True
+
+# Automatically remove unused dependencies
+apt_unattended_upgrades_autoremove: True
+
+
+# ---- Other ----
 
 apt_debian_http_mirror: 'cdn.debian.net'
 

--- a/playbooks/roles/apt/tasks/unattended-upgrades.yml
+++ b/playbooks/roles/apt/tasks/unattended-upgrades.yml
@@ -4,14 +4,14 @@
   apt: pkg={{ item }} state=latest install_recommends=False
   with_items:
     - unattended-upgrades
-  when: apt_unattended_upgrades is defined and apt_unattended_upgrades == True
+  when: apt_unattended_upgrades is defined and apt_unattended_upgrades
 
 - name: Configure unattended-upgrades
   template: src={{ item }}.j2 dest=/{{ item }} owner=root group=root mode=0644
   with_items:
     - 'etc/apt/apt.conf.d/20auto-upgrades'
     - 'etc/apt/apt.conf.d/50unattended-upgrades'
-  when: apt_unattended_upgrades is defined and apt_unattended_upgrades == True
+  when: apt_unattended_upgrades is defined and apt_unattended_upgrades
 
 - name: Remove unattended-upgrades if disabled
   apt: pkg={{ item }} state=absent purge=yes

--- a/playbooks/roles/apt/templates/etc/apt/apt.conf.d/20auto-upgrades.j2
+++ b/playbooks/roles/apt/templates/etc/apt/apt.conf.d/20auto-upgrades.j2
@@ -1,6 +1,6 @@
 // {{ ansible_managed }}
 
 APT::Periodic::Update-Package-Lists "1";
-APT::Periodic::Unattended-Upgrade "{{ apt_unattended_upgrades_auto | default('1') }}";
+APT::Periodic::Unattended-Upgrade "1";
 
 

--- a/playbooks/roles/apt/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
+++ b/playbooks/roles/apt/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
@@ -14,10 +14,11 @@ Unattended-Upgrade::Origins-Pattern {
 
 // List of packages to not update
 Unattended-Upgrade::Package-Blacklist {
-	"vim";
-	"libc6";
-//	"libc6-dev";
-//	"libc6-i686";
+{% if apt_unattended_upgrades_blacklist is defined and apt_unattended_upgrades_blacklist %}
+{% for package in apt_unattended_upgrades_blacklist %}
+        "{{ package }}";
+{% endfor %}
+{% endif %}
 };
 
 // This option allows you to control if on a unclean dpkg exit
@@ -41,15 +42,23 @@ Unattended-Upgrade::MinimalSteps "true";
 // If empty or unset then no email is sent, make sure that you
 // have a working mail setup on your system. A package that provides
 // 'mailx' must be installed. E.g. "user@example.com"
-Unattended-Upgrade::Mail "{{ apt_unattended_upgrades_mail | join(",") }}";
+Unattended-Upgrade::Mail "{{ apt_mail_notifications | join(",") }}";
 
 // Set this value to "true" to get emails only on errors. Default
 // is to always send a mail if Unattended-Upgrade::Mail is set
-//Unattended-Upgrade::MailOnlyOnError "true";
+{% if apt_unattended_upgrades_notify_always is defined and apt_unattended_upgrades_notify_always %}
+Unattended-Upgrade::MailOnlyOnError "false";
+{% else %}
+Unattended-Upgrade::MailOnlyOnError "true";
+{% endif %}
 
 // Do automatic removal of new unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)
-//Unattended-Upgrade::Remove-Unused-Dependencies "false";
+{% if apt_unattended_upgrades_autoremove is defined and apt_unattended_upgrades_autoremove %}
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+{% else %}
+Unattended-Upgrade::Remove-Unused-Dependencies "false";
+{% endif %}
 
 // Automatically reboot *WITHOUT CONFIRMATION* if a
 // the file /var/run/reboot-required is found after the upgrade


### PR DESCRIPTION
- you can meow define a blacklist of packages which you don't want to
  upgrade automatically;
- you can disable or enable automatic removal of unused packages and
  toggle mail notifications to be sent always (default) or only on errors;
