### PR TITLE
Add 'ferm' dependency in 'nginx' role

### DIFF
--- a/contrib/graphviz/ginas-role-dependencies.dot
+++ b/contrib/graphviz/ginas-role-dependencies.dot
@@ -225,6 +225,9 @@ digraph ginas_role_dependencies {
 	role_postgresql -> role_etc_services;
 	role_postgresql -> role_ferm;
 
+	edge [color = tomato3];
+	role_nginx -> role_ferm;
+
 	/* ---- Playbook: owncloud.yml ---- */
 	edge [color = aquamarine3];
 	role_owncloud -> role_mysql;

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -2,6 +2,15 @@
 # role: nginx (eNgineX web server)
 
 
+# List of IP addresses or CIDR networks allowed to connect to HTTP or HTTPS
+# service. It will be configured in iptables firewall via 'ferm' role. If there
+# are no entries, nginx will accept connections from any IP address or network.
+# If you have multiple web services on a host, you might want to control access
+# using 'item.location_allow' option instead.
+nginx_allow: []
+nginx_group_allow: []
+nginx_host_allow: []
+
 nginx_user: 'www-data'
 
 # Nicenness, from 20 (nice) to -20 (not nice)

--- a/playbooks/roles/nginx/meta/main.yml
+++ b/playbooks/roles/nginx/meta/main.yml
@@ -1,0 +1,15 @@
+---
+
+dependencies:
+
+  - role: ferm
+    ferm_input_list:
+
+      - type: 'dport_accept'
+        dport: [ 'http', 'https' ]
+        saddr: '{{ nginx_allow + nginx_group_allow + nginx_host_allow }}'
+        accept_any: True
+        filename: 'nginx_dependency_accept'
+        weight: '05'
+
+


### PR DESCRIPTION
nginx role will use ferm role to configure access to HTTP/HTTPS in
iptables firewall.
