### PR TITLE
Add 'dhcpd' role with ISC DHCP server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ included in ginas and what's their relationship with each other. Below you can
 see a basic structure of the main ginas playbook (click on the image to see
 it in full size):
 
-[![ginas at a glance](http://i.imgur.com/fvNjMug.png)](http://i.imgur.com/fvNjMug.png)
+[![ginas at a glance](http://i.imgur.com/QLaWYga.png)](http://i.imgur.com/QLaWYga.png)
 
 Next graph shows Ansible role dependencies, represented by dashed lines. Here
 you can see what roles depend on each other. Dependencies of a role are
 executed before that role, and certain roles can be run multiple times by
 Ansible:
 
-[![ginas role dependencies](http://i.imgur.com/an9iJwl.png)](http://i.imgur.com/an9iJwl.png)
+[![ginas role dependencies](http://i.imgur.com/STyDh5B.png)](http://i.imgur.com/STyDh5B.png)
 

--- a/contrib/graphviz/ginas-role-dependencies.dot
+++ b/contrib/graphviz/ginas-role-dependencies.dot
@@ -17,6 +17,7 @@ digraph ginas_role_dependencies {
 	role_auth		[label = "auth"];
 	role_boxbackup		[label = "boxbackup"];
 	role_console		[label = "console"];
+	role_dhcpd		[label = "dhcpd"];
 	role_directories	[label = "directories"];
 	role_dnsmasq		[label = "dnsmasq"];
 	role_etc_services	[label = "etc_services"];
@@ -66,6 +67,7 @@ digraph ginas_role_dependencies {
 			<tr><td port="ginas_lxc" border="1" bgcolor="seagreen3"><font color="white">LXC support</font></td></tr>
 
 			<tr><td port="services_yml" border="1" bgcolor="gray70">Playbook: services.yml</td></tr>
+			<tr><td port="ginas_dhcpd" border="1" bgcolor="royalblue"><font color="white">DHCP server support</font></td></tr>
 			<tr><td port="ginas_sks" border="1" bgcolor="darkolivegreen3"><font color="white">SKS support</font></td></tr>
 			<tr><td port="ginas_nfs" border="1" bgcolor="firebrick3"><font color="white">NFS support</font></td></tr>
 			<tr><td port="ginas_samba" border="1" bgcolor="lightpink3"><font color="white">Samba support</font></td></tr>
@@ -132,6 +134,9 @@ digraph ginas_role_dependencies {
 	role_nat			-> role_dnsmasq;
 
 	/* ---- Playbook: services.yml ---- */
+	edge [color = royalblue];
+	playbook:ginas_dhcpd		-> role_dhcpd;
+
 	edge [color = darkolivegreen3];
 	playbook:ginas_sks		-> role_sks;
 

--- a/contrib/travis-ci/inventory/hosts
+++ b/contrib/travis-ci/inventory/hosts
@@ -12,6 +12,10 @@ localhost ansible_connection=local
 [travis-ci]
 travis.localdomain ansible_connection=local
 
+# DHCP server
+[ginas_dhcpd]
+travis.localdomain
+
 # Local ginas development
 [ginas_recursively]
 travis.localdomain

--- a/playbooks/roles/dhcpd/defaults/main.yml
+++ b/playbooks/roles/dhcpd/defaults/main.yml
@@ -1,0 +1,166 @@
+---
+# role: dhcpd (DHCP server using ISC DHCP Server))
+
+
+# ---- Global ISC DHCP Server configuration ----
+
+# Is this DHCP server authoritative?
+dhcpd_authoritative: False
+
+# List of network interfaces to listen on for DHCP requests
+# If this list is empty, Ansible will try to guess correct interfaces
+# automatically
+dhcpd_interfaces: []
+
+# Default domain to use
+dhcpd_domain: '{{ ansible_domain }}'
+
+# List of default DNS servers. By default, point users to the same host that
+# serves them DHCP requests, on default interface. If this host is a router,
+# you might need to set DNS server to internal interface IP address.
+dhcpd_dns_servers: [ '{{ ansible_default_ipv4.address }}' ]
+
+# Max lease time in hours (default lease time is calculated below)
+dhcpd_lease_time: 24
+
+# Default global options formatted as a text block
+dhcpd_global_options: |
+  option domain-name "{{ ansible_domain }}";
+  option domain-name-servers {{ dhcpd_dns_servers | join(' ') }};
+  default-lease-time {{ (((dhcpd_lease_time / 2) + 6) * 60 * 60)|round|int }};
+  max-lease-time {{ (dhcpd_lease_time * 60 * 60)|round|int }};
+  log-facility local7;
+
+# Custom options formatted as a text block
+dhcpd_options: False
+
+
+# ---- ISC DHCP Server configuration scopes ----
+
+# These lists allow you to generate nested configuration scopes in
+# dhcpd.conf. Most of the information about them can be found in dhcpd.conf(5)
+# manual page. You can create nested configuration using Ansible variable
+# expansion (examples below).
+
+# List of general configuration parameters (work in any configuration scope):
+#  - comment: ''            add a comment to a scope
+#  - options: |             custom options for that scope defined as a text block
+#  - include: ''            path to external file to include in this scope
+
+# List of hosts (works in groups, subnets):
+#  - hosts: '' or []        list of hosts to configure in that scope; if this is
+#                           a path to a file, dhcpd will include an external file
+#                           in this scope
+
+# List of parameters specific to dhcpd_classes:
+#  - class: ''              class name
+#  - subclass:              this is a hash with expression as key and additional
+#                           options as value in a text block (see example below);
+#                           each match expression must end with a colon to indicate
+#                           hash key; optional
+
+# List of parameters specific to dhcpd_groups:
+#  - subnets: []            list of subnet scopes to group together
+#  - groups: []             list of other group scopes to include. No recursion!
+
+# List of parameters specific to dhcpd_shared_networks:
+#  - name: ''               name of shared network
+#  - subnets: []            list of subnets in a shared network (do not use
+#                           dhcpd_subnets here, because they will be duplicated
+#                           and DHCP server will not start)
+
+# List of parameters specific to dhcpd_subnets:
+#  - subnet: ''             start of a subnet range (ie.: 192.168.1.0)
+#  - netmask: ''            netmask for this subnet (ie.: 255.255.255.0)
+#  - routers: '' or []      address or list of addresses of gateway for that
+#                           subnet (ie.: 192.168.1.1)
+
+# List of parameters specific to dhcpd_hosts:
+#  - hostname: ''           hostname, without domain part
+#  - address: ''            IP address reserved for that host, optional
+#  - ethernet: ''           Ethernet MAC address of this host, optional
+
+
+# List of classes
+dhcpd_classes: []
+  #- class 'example-class'
+  #  subclass:
+  #    'match1':
+  #    'match2': |
+  #      # match2 options in a text block;
+
+  #- class 'example-empty-class'
+
+
+# List of groups
+dhcpd_groups: []
+  #- comment: 'First group'
+  #  hosts: '/etc/dhcp/dhcpd-group1-hosts.conf'
+  #  groups: '{{ dhcpd_group_second }}'
+
+# An example of group nesting
+#dhcpd_group_second:
+#  - comment: 'Second group'
+#    hosts: '/etc/dhcp/dhcpd-group2-hosts.conf'
+
+
+# List of shared networks
+dhcpd_shared_networks: []
+  #- name: 'shared-net'
+  #  comment: "Local shared network"
+  #  subnets: '{{ dhcpd_subnets_local }}'
+  #  options: |
+  #    default-lease-time 600;
+  #    max-lease-time 900;
+
+
+# List of subnets not in a shared network
+dhcpd_subnets:
+  - subnet: '{{ ansible_default_ipv4.network }}'
+    netmask: '{{ ansible_default_ipv4.netmask }}'
+    comment: 'Generated automatically by Ansible'
+
+  #- subnet: 'dead:be:ef::/64'
+  #  ipv6: True
+  #  routers: '10.0.10.1'
+  #  comment: "Example IPv6 subnet"
+  #  options: |
+  #    default-lease-time 300;
+  #    max-lease-time 7200;
+  #
+  #- subnet: '10.0.20.0'
+  #  netmask: '255.255.255.0'
+  #  comment: 'Ignored subnet'
+
+# An example subnets included in a shared network
+#dhcpd_subnets_local:
+#  - subnet: '10.0.30.0'
+#    netmask: '255.255.255.0'
+#    routers: [ '10.0.30.1', '10.0.30.2' ]
+#
+#  - subnet: '10.0.40.0'
+#    netmask: '255.255.255.0'
+#    routers: '19.0.40.1'
+#    options: |
+#      default-lease-time 300;
+#      max-lease-time 7200;
+#    pools:
+#      - comment: "A pool in a subnet"
+#        range: '10.0.30.10 10.0.30.20'
+
+
+# Global list of hosts in DHCP
+dhcpd_hosts: []
+#  - hostname: 'examplehost'
+#    address: '10.0.10.1'
+#    ethernet: '00:00:00:00:00:00'
+
+# Example global list of hosts read from an external file
+#dhcpd_hosts: '/etc/dhcp/dhcpd.hosts.conf'
+
+
+# List of external files to include
+dhcpd_includes: []
+  #- '/etc/dhcp/example.conf'
+
+

--- a/playbooks/roles/dhcpd/handlers/main.yml
+++ b/playbooks/roles/dhcpd/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Restart isc-dhcp-server
+  service: name=isc-dhcp-server state=restarted
+
+

--- a/playbooks/roles/dhcpd/tasks/main.yml
+++ b/playbooks/roles/dhcpd/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Install DHCP server packages
+  apt: pkg={{ item }} state=latest install_recommends=no
+  with_items: [ 'isc-dhcp-server' ]
+
+- name: Configure DHCP server
+  template: src={{ item }}.j2 dest=/{{ item }} owner=root group=root mode=0644
+  with_items: [ 'etc/default/isc-dhcp-server', 'etc/dhcp/dhcpd.conf' ]
+  notify: Restart isc-dhcp-server
+
+
+

--- a/playbooks/roles/dhcpd/templates/etc/default/isc-dhcp-server.j2
+++ b/playbooks/roles/dhcpd/templates/etc/default/isc-dhcp-server.j2
@@ -1,0 +1,35 @@
+# {{ ansible_managed }}
+
+# Defaults for isc-dhcp-server initscript
+# sourced by /etc/init.d/isc-dhcp-server
+# installed at /etc/default/isc-dhcp-server by the maintainer scripts
+
+#
+# This is a POSIX shell fragment
+#
+
+# Path to dhcpd's config file (default: /etc/dhcp/dhcpd.conf).
+#DHCPD_CONF=/etc/dhcp/dhcpd.conf
+
+# Path to dhcpd's PID file (default: /var/run/dhcpd.pid).
+#DHCPD_PID=/var/run/dhcpd.pid
+
+# Additional options to start dhcpd with.
+#	Don't use options -cf or -pf here; use DHCPD_CONF/ DHCPD_PID instead
+#OPTIONS=""
+
+# On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
+#	Separate multiple interfaces with spaces, e.g. "eth0 eth1".
+{% if dhcpd_interfaces is defined and dhcpd_interfaces %}
+INTERFACES="{{ dhcpd_interfaces | join(' ') }}"
+{% else %}
+{% set dhcpd_tpl_interfaces = [] %}
+{% for interface in ansible_interfaces %}
+{% if interface != 'lo' and ((hostvars[inventory_hostname]['ansible_'+interface].ipv4 is defined and hostvars[inventory_hostname]['ansible_'+interface].ipv4) or (hostvars[inventory_hostname]['ansible_'+interface].ipv6 is defined and hostvars[inventory_hostname]['ansible_'+interface].ipv6)) %}
+{% if dhcpd_tpl_interfaces.append(interface) %}{% endif %}
+{% endif %}
+{% endfor %}
+INTERFACES="{{ dhcpd_tpl_interfaces | join(' ') }}"
+{% endif %}
+
+

--- a/playbooks/roles/dhcpd/templates/etc/dhcp/dhcpd.conf.j2
+++ b/playbooks/roles/dhcpd/templates/etc/dhcp/dhcpd.conf.j2
@@ -1,0 +1,189 @@
+# {{ ansible_managed }}
+{% macro print_class(class) %}
+{% if class.comment is defined and class.comment %}
+# {{ class.comment }}
+{% endif %}
+class "{{ class.class }}" {
+{% if class.options is defined and class.options %}
+{{ class.options | indent(8,true) }}
+{% endif %}
+{% if class.include is defined and class.include %}
+        include "{{ class.include }}";
+{% endif %}
+}
+{% if class.subclass is defined and class.subclass %}
+
+{% for key, value in class.subclass.iteritems() %}
+{% if value is defined and value %}
+subclass "{{ class.class }}" "{{ key }}" {
+{{ value | indent(8,true) }}
+}
+
+{% else %}
+subclass "{{ class.class }}" {{ key }};
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endmacro %}
+{% macro print_group(group) %}
+{% if group.comment is defined and group.comment %}
+# {{ group.comment }}
+{% endif %}
+group {
+{% if group.options is defined and group.options %}
+{{ group.options | indent(8,true) }}
+{% endif %}
+{% if group.include is defined and group.include %}
+        include "{{ group.include }}";
+{% endif %}
+{% if group.groups is defined and group.groups %}
+{% for group in group.groups %}
+{{ print_group(group) | indent(8, true) }}
+{% endfor %}
+{% endif %}
+{% if group.subnets is defined and group.subnets %}
+{% for subnet in group.subnets %}
+{{ print_subnet(subnet) | indent(8, true) }}
+{% endfor %}
+{% endif %}
+{% if group.hosts is defined and group.hosts %}
+{{ print_hosts(group.hosts) | indent(8, true) }}
+{% endif %}
+}
+{% endmacro %}
+{% macro print_subnet(subnet) %}
+{% if subnet.comment is defined and subnet.comment %}
+# {{ subnet.comment }}
+{% endif %}
+{% if subnet.ipv6 is defined and subnet.ipv6 %}
+subnet6 {{ subnet.subnet }} {
+{% else %}
+subnet {{ subnet.subnet }} netmask {{ subnet.netmask }} {
+{% endif %}
+{% if subnet.routers is defined and subnet.routers %}
+{% if subnet.routers is string %}
+        option routers {{ subnet.routers }};
+{% else %}
+        option routers {{ subnet.routers | join(' ') }};
+{% endif %}
+{% endif %}
+{% if subnet.options is defined and subnet.options %}
+{{ subnet.options | indent(8,true) }}
+{% endif %}
+{% if subnet.include is defined and subnet.include %}
+        include "{{ subnet.include }}";
+{% endif %}
+{% if subnet.pools is defined and subnet.pools %}
+{% for pool in subnet.pools %}
+        pool {
+{% if pool.comment is defined and pool.comment %}
+                # {{ pool.comment }}
+{% endif %}
+{% if subnet.ipv6 is defined and subnet.ipv6 %}
+                range6 {{ pool.range }};
+{% else %}
+                range {{ pool.range }};
+{% endif %}
+{% if pool.options is defined and pool.options %}
+{{ pool.options | indent(16,true) }}
+{% endif %}
+{% if pool.include is defined and pool.include %}
+        include "{{ pool.include }}";
+{% endif %}
+        }
+{% endfor %}
+{% endif %}
+{% if subnet.hosts is defined and subnet.hosts %}
+{{ print_hosts(subnet.hosts) | indent(8, true) }}
+{% endif %}
+}
+{% endmacro %}
+{% macro print_hosts(hosts) %}
+{% if hosts is string %}
+include "{{ hosts }}";
+{% else %}
+{% for host in hosts %}
+{% if host.comment is defined and host.comment %}
+# {{ host.comment }}
+{% endif %}
+host {{ host.hostname }} {
+{% if host.options is defined and host.options %}
+{{ host.options | indent(8,true) }}
+{% endif %}
+{% if host.ethernet is defined and host.ethernet %}
+        hardware ethernet {{ host.ethernet }};
+{% endif %}
+{% if host.address is defined and host.address %}
+        fixed-address {{ host.address }};
+{% endif %}
+}
+{% endfor %}
+{% endif %}
+{% endmacro %}
+
+{% if dhcpd_authoritative is defined and dhcpd_authoritative %}
+authoritative;
+
+{% elif dhcpd_authoritative is undefined or (dhcpd_authoritative is defined and not dhcpd_authoritative) %}
+not authoritative;
+
+{% endif %}
+{% if dhcpd_global_options is defined and dhcpd_global_options %}
+# Global configuration options
+{{ dhcpd_global_options }}
+
+{% endif %}
+{% if dhcpd_options is defined and dhcpd_options %}
+# Configuration options
+{{ dhcpd_options }}
+
+{% endif %}
+{% if dhcpd_classes is defined and dhcpd_classes %}
+{% for class in dhcpd_classes %}
+{{ print_class(class) }}
+{% endfor %}
+{% endif %}
+{% if dhcpd_shared_networks is defined and dhcpd_shared_networks %}
+{% for network in dhcpd_shared_networks %}
+{% if network.subnets is defined and network.subnets %}
+{% if network.comment is defined and network.comment %}
+# {{ network.comment }}
+{% endif %}
+shared-network "{{ network.name }}" {
+{% if network.options is defined and network.options %}
+{{ network.options | indent(8,true) }}
+{% endif %}
+{% if network.include is defined and network.include %}
+        include "{{ network.include }}";
+{% endif %}
+{% for subnet in network.subnets %}
+
+{{ print_subnet(subnet) | indent(8,true) }}
+{% endfor %}
+}
+
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if dhcpd_groups is defined and dhcpd_groups %}
+{% for group in dhcpd_groups %}
+{{ print_group(group) }}
+{% endfor %}
+{% endif %}
+{% if dhcpd_subnets is defined and dhcpd_subnets %}
+{% for subnet in dhcpd_subnets %}
+{{ print_subnet(subnet) }}
+{% endfor %}
+{% endif %}
+{% if dhcpd_hosts is defined and dhcpd_hosts %}
+{{ print_hosts(dhcpd_hosts) }}
+{% endif %}
+{% if dhcpd_includes is defined and dhcpd_includes %}
+{% for include in dhcpd_includes %}
+include "{{ include }}";
+{% endfor %}
+
+{% endif %}
+{#
+    vim: ft=dhcpd
+#}

--- a/playbooks/services.yml
+++ b/playbooks/services.yml
@@ -1,5 +1,14 @@
 ---
 
+# DHCP server
+- name: DHCP server support
+  hosts: ginas_dhcpd
+  sudo: yes
+
+  roles:
+    - { role: dhcpd, tags: dhcpd }
+
+
 # SKS Keyserver
 - name: SKS Keyserver support
   hosts: ginas_sks


### PR DESCRIPTION
- 'dhcpd' role currently installs and configures ISC DHCP server from
  the Debian repository;
- DHCP server will be configured with basic subnet detected
  automatically by default, if you want to include it in a shared
  network or group, you will need to set 'dhcpd_subnets' variable to []
  in inventory;
- 'dhcpd' role will try to detect network interfaces automatically, this
  can be overriden using 'dhcpd_interfaces' list;
