### PR TITLE
Check existence of 'ansible_local.mailman' fact

### DIFF
--- a/playbooks/roles/postfix/templates/etc/postfix/hash_tables/mailman_transport.j2
+++ b/playbooks/roles/postfix/templates/etc/postfix/hash_tables/mailman_transport.j2
@@ -7,7 +7,7 @@
 {% for domain in postfix_mailman_domains %}
 {{ domain }}		mailman:
 {% endfor %}
-{% elif ansible_local is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains %}
+{% elif ansible_local is defined and ansible_local.mailman is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains %}
 {% for domain in ansible_local.mailman.mailman.domains.split(',') %}
 {{ domain }}		mailman:
 {% endfor %}
@@ -25,7 +25,7 @@
 # postfix_relayhost = {{ postfix_relayhost }}
 {% if postfix_mailman_domains is defined and postfix_mailman_domains %}
 # postfix_mailman_domains = {{ postfix_mailman_domains|join(',') }}
-{% elif ansible_local is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains %}
+{% elif ansible_local is defined and ansible_local.mailman is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains %}
 # postfix_mailman_domains = {{ ansible_local.mailman.mailman.domains }}
 {% else %}
 # postfix_mailman_domains not defined

--- a/playbooks/roles/postfix/templates/etc/postfix/main.cf.d/10_basic_options.j2
+++ b/playbooks/roles/postfix/templates/etc/postfix/main.cf.d/10_basic_options.j2
@@ -29,7 +29,7 @@ alias_database			= hash:/etc/aliases
 {% if ('mx' in postfix or 'submission' in postfix) and 'local' not in postfix %}
 {% set postfix_tpl_virtual_alias_maps = postfix_tpl_virtual_alias_maps + ['hash:${config_directory}/hash_tables/mx_relay_virtual_alias_maps'] %}
 {% endif %}
-{% if 'mailman' in postfix and 'local' in postfix and ((postfix_mailman_domains is defined and postfix_mailman_domains) or (ansible_local is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains)) %}
+{% if 'mailman' in postfix and 'local' in postfix and ((postfix_mailman_domains is defined and postfix_mailman_domains) or (ansible_local is defined and ansible_local.mailman is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains)) %}
 {% set postfix_tpl_virtual_alias_maps = postfix_tpl_virtual_alias_maps + [ 'hash:/var/lib/mailman/data/virtual-mailman' ] %}
 {% endif %}
 {% if postfix_virtual_alias_maps is defined and postfix_virtual_alias_maps %}
@@ -69,7 +69,7 @@ mynetworks			= {{ ', '.join(postfix_mynetworks + ['127.0.0.0/8','[::ffff:127.0.0
 {% if 'mailman' in postfix and 'local' in postfix %}
 {% if postfix_mailman_domains is defined and postfix_mailman_domains %}
 {% set postfix_tpl_virtual_alias_domains = postfix_tpl_virtual_alias_domains + postfix_mailman_domains %}
-{% elif ansible_local is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains %}
+{% elif ansible_local is defined and ansible_local.mailman is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains %}
 {% set postfix_tpl_virtual_alias_domains = postfix_tpl_virtual_alias_domains + ansible_local.mailman.mailman.domains.split(',') %}
 {% else %}
 # postfix_mailman_domains not defined
@@ -86,7 +86,7 @@ virtual_alias_domains		= {{ ', '.join(postfix_tpl_virtual_alias_domains) }}
 {% if 'mailman' in postfix and 'local' not in postfix %}
 {% if postfix_mailman_domains is defined and postfix_mailman_domains %}
 {% set postfix_tpl_relay_domains = postfix_tpl_relay_domains + [ postfix_mailman_domains[0] ] %}
-{% elif ansible_local is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains %}
+{% elif ansible_local is defined and ansible_local.mailman is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains %}
 {% set postfix_tpl_relay_domains = postfix_tpl_relay_domains + [ ansible_local.mailman.mailman.domains.split(',')[0] ] %}
 {% else %}
 # postfix_mailman_domains not defined
@@ -100,7 +100,7 @@ relay_domains			= {{ ', '.join(postfix_tpl_relay_domains) }}
 {% if 'mx' in postfix and postfix_relay_recipient_maps is defined and postfix_relay_recipient_maps %}
 {% set postfix_tpl_relay_recipient_maps = postfix_tpl_relay_recipient_maps + postfix_relay_recipient_maps %}
 {% endif %}
-{% if 'mailman' in postfix and 'local' not in postfix and ((postfix_mailman_domains is defined and postfix_mailman_domains) or (ansible_local is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains)) %}
+{% if 'mailman' in postfix and 'local' not in postfix and ((postfix_mailman_domains is defined and postfix_mailman_domains) or (ansible_local is defined and ansible_local.mailman is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains)) %}
 {% set postfix_tpl_relay_recipient_maps = postfix_tpl_relay_recipient_maps + ['hash:/var/lib/mailman/data/virtual-mailman'] %}
 {% endif %}
 {% if postfix_tpl_relay_recipient_maps is defined and postfix_tpl_relay_recipient_maps %}
@@ -128,7 +128,7 @@ relayhost			= {{ ansible_domain }}
 {% if 'mx' in postfix %}
 {% set postfix_tpl_transport_maps = postfix_tpl_transport_maps + ['hash:${config_directory}/hash_tables/mx_relay_transport'] %}
 {% endif %}
-{% if 'mailman' in postfix and 'local' not in postfix and ((postfix_mailman_domains is defined and postfix_mailman_domains) or (ansible_local is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains)) %}
+{% if 'mailman' in postfix and 'local' not in postfix and ((postfix_mailman_domains is defined and postfix_mailman_domains) or (ansible_local is defined and ansible_local.mailman is defined and ansible_local.mailman.mailman.domains is defined and ansible_local.mailman.mailman.domains)) %}
 {% set postfix_tpl_transport_maps = postfix_tpl_transport_maps + ['hash:${config_directory}/hash_tables/mailman_transport'] %}
 {% endif %}
 {% if postfix_tpl_transport_maps %}


### PR DESCRIPTION
Without this check, if other local facts are defined, but not mailman
facts, Postfix role will fail during template generation.
