### PR TITLE
Add 'ntp' role

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ included in ginas and what's their relationship with each other. Below you can
 see a basic structure of the main ginas playbook (click on the image to see
 it in full size):
 
-[![ginas at a glance](http://i.imgur.com/9OSa7Ip.png)](http://i.imgur.com/9OSa7Ip.png)
+[![ginas at a glance](http://i.imgur.com/hKhet35.png)](http://i.imgur.com/hKhet35.png)
 
 Next graph shows Ansible role dependencies, represented by dashed lines. Here
 you can see what roles depend on each other. Dependencies of a role are
 executed before that role, and certain roles can be run multiple times by
 Ansible:
 
-[![ginas role dependencies](http://i.imgur.com/pAQ23j3.png)](http://i.imgur.com/pAQ23j3.png)
+[![ginas role dependencies](http://i.imgur.com/hqEvS4k.png)](http://i.imgur.com/hqEvS4k.png)
 

--- a/contrib/graphviz/ginas-role-dependencies.dot
+++ b/contrib/graphviz/ginas-role-dependencies.dot
@@ -34,6 +34,7 @@ digraph ginas_role_dependencies {
 	role_nat		[label = "nat"];
 	role_nfs		[label = "nfs"];
 	role_nginx		[label = "nginx"];
+	role_ntp		[label = "ntp"];
 	role_openvz		[label = "openvz"];
 	role_owncloud		[label = "owncloud"];
 	role_php5		[label = "php5"];
@@ -113,7 +114,8 @@ digraph ginas_role_dependencies {
 	role_auth			-> role_pki;
 	role_pki			-> role_apt;
 	role_apt			-> role_ferm;
-	role_ferm			-> role_monkeysphere;
+	role_ferm			-> role_ntp;
+	role_ntp			-> role_monkeysphere;
 	role_monkeysphere		-> role_sshd;
 	role_sshd			-> role_interfaces;
 	role_interfaces			-> role_console;
@@ -196,6 +198,8 @@ digraph ginas_role_dependencies {
 	role_apt -> role_ferm;
 	role_apt -> role_nginx;
 	role_apt -> role_reprepro;
+
+        role_ntp -> role_ferm;
 
 	role_postfix -> role_pki;
 	role_postfix -> role_ferm;

--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -27,6 +27,7 @@
     - { role: pki, tags: pki }
     - { role: apt, tags: apt }
     - { role: ferm, tags: ferm }
+    - { role: ntp, tags: ntp }
     - { role: monkeysphere, tags: monkeysphere }
     - { role: sshd, tags: sshd }
     - { role: interfaces, tags: interfaces }

--- a/playbooks/roles/apt/tasks/install_conditional.yml
+++ b/playbooks/roles/apt/tasks/install_conditional.yml
@@ -23,8 +23,3 @@
     #- linux-image-amd64
   when: ansible_processor_cores > 2 and ansible_virtualization_role is undefined or ansible_virtualization_role is defined and ansible_virtualization_role == 'host'
 
-# Install openntpd only on bare metal and KVM hosts, exclude containers
-- name: Install openntpd where it's needed
-  apt: pkg=openntpd state=latest install_recommends=no
-  when: ansible_virtualization_type is undefined or ansible_virtualization_type is defined and ansible_virtualization_type != 'lxc'
-

--- a/playbooks/roles/ntp/defaults/main.yml
+++ b/playbooks/roles/ntp/defaults/main.yml
@@ -1,0 +1,32 @@
+---
+# role: ntp - timezone and clock management
+
+
+# Which clock management daemon should be installed? Currently only 'openntpd'
+# is supported. Set to False to disable clock management
+ntp: 'openntpd'
+
+# Timezone configuration
+# This is a two element list:
+#   - first element is the "Area" (Europe, Asia, America, Etc, ...)
+#   - second element is the "Zone" (Warsaw, Tokyo, Chicago, UTC, ...)
+# Run 'dpkg-reconfigure tzdata' to see list of possible values
+# If this variable is empty or False, timezone won't be changed
+ntp_timezone: []
+
+# List of interfaces ntpd should listen on. Specify '*' to listen on all
+# interfaces. If this list is not empty, ntp port will be opened in firewall
+ntp_listen: []
+
+# List of hosts/networks in CIDR format to allow access to ntp port in
+# firewall. If this list is empty, access will be allowed from anywhere. You
+# should probably define a list of networks allowed access to mitigate NTP
+# amplification attacks
+ntp_allow: []
+
+# List of NTP servers to synchronize with
+ntp_servers: [ '0.debian.pool.ntp.org',
+               '1.debian.pool.ntp.org',
+               '2.debian.pool.ntp.org',
+               '3.debian.pool.ntp.org' ]
+

--- a/playbooks/roles/ntp/handlers/main.yml
+++ b/playbooks/roles/ntp/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Restart openntpd
+  service: name=openntpd state=restarted

--- a/playbooks/roles/ntp/meta/main.yml
+++ b/playbooks/roles/ntp/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+
+  - role: ferm

--- a/playbooks/roles/ntp/tasks/main.yml
+++ b/playbooks/roles/ntp/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+
+- name: Configure tzdata area in debconf
+  debconf: name=tzdata question='tzdata/Areas'
+           vtype='select' value='{{ ntp_timezone[0] }}'
+  register: ntp_debconf_set_area
+  when: ntp_timezone is defined and ntp_timezone
+
+- name: Configure tzdata zone in debconf
+  debconf: name=tzdata question='tzdata/Zones/{{ ntp_timezone[0] }}'
+           vtype='select' value='{{ ntp_timezone[1] }}'
+  register: ntp_debconf_set_zone
+  when: ntp_timezone is defined and ntp_timezone
+
+  # tzdata ignores debconf answers when configured non-interactively
+  # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=704089
+- name: Configure timezone in /etc/timezone
+  copy: content='{{ ntp_timezone[0] + "/" + ntp_timezone[1] }}'
+        dest=/etc/timezone owner=root group=root mode=0644
+  register: ntp_etc_timezone
+  when: ntp_timezone is defined and ntp_timezone
+
+- name: Install tzdata
+  apt: name=tzdata state=latest install_recommends=no
+
+- name: Reconfigure tzdata
+  shell: dpkg-reconfigure --frontend noninteractive tzdata
+  when: (ntp_timezone is defined and ntp_timezone) and
+        ((ntp_debconf_set_area is defined and ntp_debconf_set_area.changed) or
+         (ntp_debconf_set_zone is defined and ntp_debconf_set_zone.changed) or
+         (ntp_etc_timezone is defined and ntp_etc_timezone.changed))
+
+  # Install OpenNTPd on all hosts except inside containers
+- include: openntpd.yml
+  when: (ntp is defined and ntp == 'openntpd') and
+        ((ansible_virtualization_type is defined and
+          ansible_virtualization_role is defined and
+         (ansible_virtualization_type in ['kvm','VMware','virtualbox'] and
+          ansible_virtualization_role in ['host','guest']) or
+         (ansible_virtualization_type in ['lxc','openvz'] and
+          ansible_virtualization_role in ['host']) or
+         (ansible_virtualization_type in ['NA'] and
+          ansible_virtualization_role in ['NA'])) or
+         (ansible_virtualization_type is undefined and
+          ansible_virtualization_role is undefined))
+

--- a/playbooks/roles/ntp/tasks/openntpd.yml
+++ b/playbooks/roles/ntp/tasks/openntpd.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Install OpenNTPd package
+  apt: pkg=openntpd state=latest install_recommends=no
+
+- name: Divert original /etc/openntpd/ntpd.conf
+  command: dpkg-divert --quiet --local --divert /etc/openntpd/ntpd.conf.dpkg-divert
+           --rename /etc/openntpd/ntpd.conf creates=/etc/openntpd/ntpd.conf.dpkg-divert
+
+- name: Configure OpenNTPd
+  template: src=etc/openntpd/ntpd.conf.j2 dest=/etc/openntpd/ntpd.conf
+            owner=root group=root mode=0644
+  notify: [ 'Restart openntpd' ]
+
+- name: Configure firewall for OpenNTPd
+  template: src=etc/ferm/filter-input.d/ntpd.conf.j2 dest=/etc/ferm/filter-input.d/ntpd.conf
+            owner=root group=root mode=0644
+  notify: [ 'Restart ferm' ]

--- a/playbooks/roles/ntp/templates/etc/ferm/filter-input.d/ntpd.conf.j2
+++ b/playbooks/roles/ntp/templates/etc/ferm/filter-input.d/ntpd.conf.j2
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+
+{% if ntp_listen is defined and ntp_listen %}
+protocol (tcp udp) dport ntp {
+{% if ntp_allow is defined and ntp_allow %}
+{% for address in ntp_allow %}
+	saddr {{ address }} ACCEPT;
+{% endfor %}
+{% else %}
+	ACCEPT;
+{% endif %}
+}
+{% else %}
+# ntpd not listening on any interface
+{% endif %}

--- a/playbooks/roles/ntp/templates/etc/openntpd/ntpd.conf.j2
+++ b/playbooks/roles/ntp/templates/etc/openntpd/ntpd.conf.j2
@@ -1,0 +1,27 @@
+# {{ ansible_managed }}
+
+{% if ntp_listen is defined and ntp_listen %}
+# Addresses to listen on
+{% if ntp_listen is string %}
+listen on {{ ntp_listen }}
+
+{% else %}
+{% for address in ntp_listen %}
+listen on {{ address }}
+{% endfor %}
+
+{% endif %}
+{% else %}
+# ntpd is not listening on any interface
+
+{% endif %}
+{% if ntp_servers is defined and ntp_servers %}
+# NTP servers to synchronize with
+{% if ntp_servers is string %}
+servers {{ ntp_servers }}
+{% else %}
+{% for address in ntp_servers %}
+servers {{ address }}
+{% endfor %}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
'ntp' role managed timezone with tzdata and ntp daemon (OpenNTPd by
default). ntpd will be installed and configured on all hosts except
containers (LXC, OpenVZ), which use the host clock instead of their own.
