### PR TITLE
Set separate interfaces list var using dependency

### DIFF
--- a/playbooks/roles/interfaces/defaults/main.yml
+++ b/playbooks/roles/interfaces/defaults/main.yml
@@ -29,6 +29,9 @@ interfaces_default_config: ""
 # NetworkManager or value of ansible_virtualization_type
 # (see ../tasks/generate_interfaces.yml). Default sets are defined in ../vars/*
 # files.
+# If you want to define list of interfaces via dependency variables, set them
+# in 'interfaces_dependent_list', this variable will override other variables of
+# this type and will allow you to set your interfaces across Ansible plays.
 # Refer to interfaces(5) and https://wiki.debian.org/NetworkConfiguration to
 # see possible configuration options.
 interfaces_list: []

--- a/playbooks/roles/interfaces/tasks/generate_interfaces.yml
+++ b/playbooks/roles/interfaces/tasks/generate_interfaces.yml
@@ -7,11 +7,18 @@
     - '../vars/networkmanager_{{ interfaces_networkmanager }}.yml'
     - '../vars/virtualization_{{ ansible_virtualization_type }}.yml'
     - '../vars/default.yml'
+  when: ((interfaces_list is defined and not interfaces_list) or interfaces_list is undefined)
 
 - name: Prepare interfaces configuration if not defined
   set_fact:
     interfaces_list: '{{ interfaces_default_list }}'
-  when: interfaces_list is undefined or not interfaces_list
+  when: (interfaces_dependent_list is undefined) and
+        (interfaces_default_list is defined and interfaces_default_list)
+
+- name: Prepare interfaces configuration via dependency if defined
+  set_fact:
+    interfaces_list: '{{ interfaces_dependent_list }}'
+  when: interfaces_dependent_list is defined and interfaces_dependent_list
 
 - name: Create /etc/network/interfaces.d directory
   file: path=/etc/network/interfaces.d owner=root group=root mode=0755 state=directory

--- a/playbooks/roles/nat/meta/main.yml
+++ b/playbooks/roles/nat/meta/main.yml
@@ -3,7 +3,7 @@
 dependencies:
 
   - role: interfaces
-    interfaces_list: '{{ nat_interfaces_list }}'
+    interfaces_dependent_list: '{{ nat_interfaces_list }}'
 
   - role: ferm
 


### PR DESCRIPTION
During playbook run, 'interfaces_list' variable contains list of network
interfaces to configure by 'interfaces' role. This list can be defined
using 'set_fact' module at runtime.

Unfortunately, if a separate play is run after main common play which
adds new interfaces, 'interfaces_list' variable couldn't be overwritten
automatically. This patch changes the role to expect additional,
separate 'interfaces_dependent_list' variable - if it's set (via
dependency variables), it will override all other variables of this type
and allow to define a custom list of network interfaces by another role.

You can still define 'interfaces_list' using inventory variables.
