### PR TITLE
Allow custom relayhost for Postfix 'mx' hosts

### DIFF
--- a/playbooks/roles/postfix/templates/etc/postfix/main.cf.d/10_basic_options.j2
+++ b/playbooks/roles/postfix/templates/etc/postfix/main.cf.d/10_basic_options.j2
@@ -107,7 +107,7 @@ relay_domains			= {{ ', '.join(postfix_tpl_relay_domains) }}
 relay_recipient_maps		= {{ ', '.join(postfix_tpl_relay_recipient_maps) }}
 show_user_unknown_table_name	= no
 {% endif %}
-{% if postfix_relayhost is defined and postfix_relayhost and 'mx' not in postfix %}
+{% if postfix_relayhost is defined and postfix_relayhost %}
 {% if postfix_relayhost == True %}
 relayhost			= {{ ansible_domain }}
 


### PR DESCRIPTION
This patch will allow setting custom relayhost when 'mx' Postfix
capability is enabled.
