### PR TITLE
Remove AHBL RBL from Postfix DNSBL list

### DIFF
--- a/playbooks/roles/postfix/defaults/main.yml
+++ b/playbooks/roles/postfix/defaults/main.yml
@@ -123,10 +123,6 @@ postfix_postscreen_dnsbl_sites:
   - 'bl.spameatingmonkey.net*2'
   - 'backscatter.spameatingmonkey.net*2'
 
-  # Abusive Hosts Blocking List: http://ahbl.org/documents/dnsbl
-  # Requests contact before usage
-  #-'dnsbl.ahbl.org*2'
-
   # SpamCop Blocking List: http://www.spamcop.net/bl.shtml
   - 'bl.spamcop.net'
 


### PR DESCRIPTION
AHBL is closing down it's operations:
http://ahbl.org/content/changes-ahbl
