### PR TITLE
Support custom host fingerprints in SafeKeep role

### DIFF
--- a/playbooks/roles/safekeep/defaults/main.yml
+++ b/playbooks/roles/safekeep/defaults/main.yml
@@ -22,6 +22,11 @@ safekeep_enabled: 'true'
 # Retention time for incremental backup
 safekeep_retention: '7D'
 
+# List of additional FQDN hosts to add to SafeKeep server ~/.ssh/known_hosts
+# You should configure here hosts that are outside of Ansible cluster (not
+# controlled by a playbook) that you want to backup using SafeKeep manually
+safekeep_keyscan: []
+
 # Shell script to execute on client host during various stages of backup
 safekeep_script: '/usr/local/sbin/safekeep-client.sh'
 

--- a/playbooks/roles/safekeep/tasks/configure_server.yml
+++ b/playbooks/roles/safekeep/tasks/configure_server.yml
@@ -30,3 +30,16 @@
   file: path={{ safekeep_server_basedir }}/.ssh/known_hosts.d state=directory
         owner={{ safekeep_server_user }} group={{ safekeep_server_group }} mode=0755
 
+- name: Scan specified host fingerprints
+  shell: ssh-keyscan -H {{ item }} > {{ safekeep_server_basedir }}/.ssh/known_hosts.d/{{ item }}
+         creates={{ safekeep_server_basedir }}/.ssh/known_hosts.d/{{ item }}
+  with_items: safekeep_keyscan
+  register: safekeep_register_server_keyscan
+  when: safekeep_keyscan is defined and safekeep_keyscan
+
+- name: Assemble ~/.ssh/known_hosts
+  assemble: src={{ safekeep_server_basedir }}/.ssh/known_hosts.d
+            dest={{ safekeep_server_basedir }}/.ssh/known_hosts
+            backup=no owner={{ safekeep_server_user }} group={{ safekeep_server_group }} mode=0644
+  when: safekeep_register_server_keyscan is defined and safekeep_register_server_keyscan.changed
+


### PR DESCRIPTION
If you want to backup hosts outside of Ansible-controlled cluster
manually, you can use 'safekeep_keyscan' list variable to automatically
scan custom host fingerprints and add them to SafeKeep's
'~/.ssh/known_hosts' file.
