### PR TITLE
Add option to define address mapping in dnsmasq

### DIFF
--- a/playbooks/roles/dnsmasq/defaults/main.yml
+++ b/playbooks/roles/dnsmasq/defaults/main.yml
@@ -25,6 +25,11 @@ dnsmasq_domain_gw: 'gw'
 # Hostname of local domain mail server
 dnsmasq_domain_mx: 'gw'
 
+# List of domain->IP address mappings returned by dnsmasq
+dnsmasq_address: []
+  #'subdomain.example.org': '10.20.30.40'
+  #'.wildcard.example.org': '10.50.60.70'
+
 # List of CNAME entries
 dnsmasq_cname: []
   #'host.example.net': 'other.example.net'

--- a/playbooks/roles/dnsmasq/tasks/main.yml
+++ b/playbooks/roles/dnsmasq/tasks/main.yml
@@ -12,8 +12,8 @@
   notify:
     - Restart dnsmasq
 
-- name: Setup dnsmasq CNAME configuration
-  template: src=etc/dnsmasq.d/cname.conf.j2 dest=/etc/dnsmasq.d/{{ dnsmasq_interface }}_{{ dnsmasq_domain }}_cname.conf
+- name: Setup dnsmasq zone configuration
+  template: src=etc/dnsmasq.d/zone.conf.j2 dest=/etc/dnsmasq.d/{{ dnsmasq_interface }}_{{ dnsmasq_domain }}_zone.conf
             owner=root group=root mode=0644
   notify:
     - Restart dnsmasq

--- a/playbooks/roles/dnsmasq/templates/etc/dnsmasq.d/zone.conf.j2
+++ b/playbooks/roles/dnsmasq/templates/etc/dnsmasq.d/zone.conf.j2
@@ -1,5 +1,12 @@
 # {{ ansible_managed }}
 
+{% if dnsmasq_address is defined and dnsmasq_address %}
+# Domain -> IP address mapping
+{% for domain, ipaddress in dnsmasq_address.iteritems() %}
+address=/{{ domain }}/{{ ipaddress }}
+{% endfor %}
+
+{% endif %}
 {% if dnsmasq_cname_subdomain is defined and dnsmasq_cname_subdomain %}
 # CNAME for local domain
 {% for cname, hostname in dnsmasq_cname_subdomain.iteritems() %}


### PR DESCRIPTION
- 'cname.conf.j2' template has been renamed to 'zone.conf.j2' and will
  be used to configure zone-like information served by dnsmasq;
- you can define 'dnsmasq_address' hash variable with domain->ip address
  mapping (an --address option in dnsmasq);
