### PR TITLE
Add inventory.* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ginas patterns
 /inventory
+/inventory.*
 /inventory-*
 /*.sh
 /.vagrant


### PR DESCRIPTION
The `.gitignore` file did not include the `inventory.secret` folder. Now it does.
