### PR TITLE
Clean up and upgrade 'etc_services' role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 ginas changelog
 ===============
 
+## July 2014
+
+`postgresql` role has been modified to support more granular auth parameters in
+`pg_hba.conf` configuration files, thanks to [Nick Janetakis](https://github.com/nickjj)
+and welcome to the team!
+
+`etc_services` role can now add custom service entries using lists in inventory
+and dependency variables.
+
+
 ## June 2014
 
 After some hiatus, time to go back to work!

--- a/playbooks/roles/ginas.etc_services/defaults/main.yml
+++ b/playbooks/roles/ginas.etc_services/defaults/main.yml
@@ -8,3 +8,31 @@ etc_services: True
 # Name of diverted /etc/services, do not change if diversion is active!
 etc_services_diversion: '/etc/services.d/10_debian_etc_services'
 
+
+# ---- Local services ----
+
+# These lists allow you to generate entries for local services not included in
+# officially distributed /etc/services file. They will generate separate files
+# for each configured service in /etc/services.d/ which then will be assembled
+# into complete /etc/services file.
+
+# List of known parameters:
+#  - name: ''                 name of the service, required
+#  - port: ''                 port on which service is accessed, required
+#  - protocol: ''             protocol name to use, 'tcp' by default, optional
+#  - comment: ''              comment to add to the service entry, optional
+
+# These lists should be used in inventory
+etc_services_list: []
+etc_services_group_list: []
+etc_services_host_list: []
+
+# This list can be used in a dependency variables for 'etc_services' role
+etc_services_dependency_list: []
+
+  # Example entry
+  #- name: 'servicename'
+  #  port: '12345'
+  #  porotol: 'tcp'
+  #  comment: 'Example service'
+

--- a/playbooks/roles/ginas.etc_services/handlers/main.yml
+++ b/playbooks/roles/ginas.etc_services/handlers/main.yml
@@ -1,5 +1,7 @@
 ---
 
 - name: Assemble services.d
-  assemble: src=/etc/services.d dest=/etc/services backup=no owner=root group=root mode=0644
+  assemble: src=/etc/services.d dest=/etc/services
+            backup=no owner=root group=root mode=0644
+  when: etc_services is defined and etc_services
 

--- a/playbooks/roles/ginas.etc_services/tasks/main.yml
+++ b/playbooks/roles/ginas.etc_services/tasks/main.yml
@@ -1,24 +1,41 @@
 ---
 
 - name: Make sure /etc/services.d directory exists
-  file: path=/etc/services.d state=directory owner=root group=root mode=0755
+  file: path=/etc/services.d state=directory
+        owner=root group=root mode=0755
 
 - name: Create /etc/services.d/00_ansible
-  template: src=etc/services.d/00_ansible.j2 dest=/etc/services.d/00_ansible owner=root group=root mode=0644
+  template: src=etc/services.d/00_ansible.j2 dest=/etc/services.d/00_ansible
+            owner=root group=root mode=0644
 
 - name: Divert original /etc/services
-  command: dpkg-divert --quiet --local --divert {{ etc_services_diversion }} --rename /etc/services creates={{ etc_services_diversion }}
+  command: dpkg-divert --quiet --local --divert {{ etc_services_diversion }}
+           --rename /etc/services creates={{ etc_services_diversion }}
   when: etc_services is defined and etc_services
 
+- name: Generate list of local services if requested
+  template: src=etc/services.d/local_service.j2 dest=/etc/services.d/20_local_service_{{ item.name }}
+            owner=root group=root mode=0644
+  with_flattened:
+    - etc_services_list
+    - etc_services_group_list
+    - etc_services_host_list
+    - etc_services_dependency_list
+  when: (etc_services is defined and etc_services) and
+        (item.name is defined and item.name) and
+        (item.port is defined and item.port)
+
 - name: Assemble /etc/services.d
-  assemble: src=/etc/services.d dest=/etc/services backup=no owner=root group=root mode=0644
+  assemble: src=/etc/services.d dest=/etc/services
+            backup=no owner=root group=root mode=0644
   when: etc_services is defined and etc_services
 
 - name: Move current /etc/services out of the way before reversion
   command: rm -f /etc/services removes={{ etc_services_diversion }}
-  when: etc_services is undefined or etc_services is defined and etc_services == False
+  when: etc_services is undefined or (etc_services is defined and etc_services == False)
 
 - name: Remove diversion of /etc/services
-  command: dpkg-divert --quiet --local --rename --remove /etc/services removes={{ etc_services_diversion }}
-  when: etc_services is undefined or etc_services is defined and etc_services == False
+  command: dpkg-divert --quiet --local --rename --remove /etc/services
+           removes={{ etc_services_diversion }}
+  when: etc_services is undefined or (etc_services is defined and etc_services == False)
 

--- a/playbooks/roles/ginas.etc_services/templates/etc/services.d/local_service.j2
+++ b/playbooks/roles/ginas.etc_services/templates/etc/services.d/local_service.j2
@@ -1,0 +1,12 @@
+{% if item.name is defined and item.name %}
+{% if item.protocol is undefined %}
+{% set etc_services_tpl_local_protocol = 'tcp' %}
+{% else %}
+{% set etc_services_tpl_local_protocol = item.protocol %}
+{% endif %}
+{% if item.comment is undefined %}
+{{ "%-15s %s/%s" | format(item.name, item.port, etc_services_tpl_local_protocol) }}
+{% else %}
+{{ "%-15s %s/%-26s # %s" | format(item.name, item.port, etc_services_tpl_local_protocol, item.comment) }}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
You can now use 'etc_services_*_list' variables to define custom
services that should be added in '/etc/services' file, either via
inventory or role dependency variables.
