### PR TITLE
Clean up 'directories' role

### DIFF
--- a/playbooks/roles/ginas.directories/defaults/main.yml
+++ b/playbooks/roles/ginas.directories/defaults/main.yml
@@ -2,12 +2,18 @@
 # role: directories (create or remove directories)
 
 
-#directories_list:
+# List of global directories
+directories_list: []
 
-  # Example entry
-  #- path: '/root'
+  #- path: '/tmp/directory'             # required
   #  state: 'directory'
   #  owner: 'root'
-  #  group: 'root"
-  #  mode: '0700'
+  #  group: 'root'
+  #  mode: '0755'
+
+# List of directories in a host group
+directories_group_list: []
+
+# List of directories on a specific host
+directories_host_list: []
 

--- a/playbooks/roles/ginas.directories/tasks/main.yml
+++ b/playbooks/roles/ginas.directories/tasks/main.yml
@@ -1,7 +1,15 @@
 ---
 
-- name: Make sure requested directories exist
-  file: path={{ item.path }} state={{ item.state | default('directory') }} owner={{ item.owner | default('root') }} group={{ item.group | default('root') }} mode={{ item.mode | default('0755') }}
-  with_items: [ '{{ directories_list }}' ]
-  when: directories_list is defined and directories_list and item.path is defined and item.path
+- name: Create custom directories
+  file:
+    path: '{{ item.path }}'
+    state: '{{ item.state | default("directory") }}'
+    owner: '{{ item.owner | default("root") }}'
+    group: '{{ item.group | default("root") }}'
+    mode: '{{ item.mode | default("0755") }}'
+  with_flattened:
+    - directories_list
+    - directories_group_list
+    - directories_host_list
+  when: (item.path is defined and item.path)
 


### PR DESCRIPTION
Now 'directories' role supports creation of directories from multiple
levels of inventory (global, group, host) and syntax is cleaner.
