### PR TITLE
Fix an issue relating to when no sentinels exist

### DIFF
--- a/playbooks/roles/ginas.redis/tasks/server.yml
+++ b/playbooks/roles/ginas.redis/tasks/server.yml
@@ -82,7 +82,7 @@
   shell: "redis-cli {{ '-a ' + redis_requirepass if redis_requirepass else '' }} -h {{ redis_sentinel_hosts_group[0] }} -p {{ redis_sentinel_port }} info | grep 'address=' | awk -F 'address=' '{print $2}' | tr ',' '\n' | grep ':' | awk -F ':' '{print $1}'"
   changed_when: False
   when: not redis_register_main_config_slaveof.stdout and
-        redis_sentinel_hosts_group in groups and redis_sentinel_hosts_group and
+        redis_sentinel_hosts_group in groups and redis_sentinel_hosts_group
   register: redis_register_real_master
 
 - name: Insert the real slaveof to all slaves


### PR DESCRIPTION
The tasks below would error out if no sentinel groups exist. This fixes it.
