### PR TITLE
Use ginas.redis as a dependency

### DIFF
--- a/playbooks/roles/ginas.gitlab/meta/main.yml
+++ b/playbooks/roles/ginas.gitlab/meta/main.yml
@@ -8,6 +8,8 @@ dependencies:
 
   - role: ginas.ruby
 
+  - role: ginas.redis
+
   - role: ginas.mysql
     when: (gitlab_dependencies is defined and gitlab_dependencies) and
           (gitlab_database is defined and gitlab_database and gitlab_database == 'mysql')

--- a/playbooks/roles/ginas.gitlab/tasks/main.yml
+++ b/playbooks/roles/ginas.gitlab/tasks/main.yml
@@ -4,7 +4,7 @@
   apt: pkg={{ item }} state=latest install_recommends=no
   with_items: [ 'build-essential', 'zlib1g-dev', 'libyaml-dev', 'libssl-dev',
                 'libgdbm-dev', 'libreadline-dev', 'libncurses5-dev', 'libffi-dev',
-                'redis-server', 'libxml2-dev', 'libxslt1-dev', 'libcurl4-openssl-dev',
+                'libxml2-dev', 'libxslt1-dev', 'libcurl4-openssl-dev',
                 'libicu-dev', 'python-docutils' ]
 
 - name: Install required MySQL database packages

--- a/playbooks/roles/ginas.gitlab_ci/meta/main.yml
+++ b/playbooks/roles/ginas.gitlab_ci/meta/main.yml
@@ -8,6 +8,8 @@ dependencies:
 
   - role: ginas.ruby
 
+  - role: ginas.redis
+
   - role: ginas.mysql
     when: (gitlab_ci_dependencies is defined and gitlab_ci_dependencies) and
           (gitlab_ci_database is defined and gitlab_ci_database and gitlab_ci_database == 'mysql')

--- a/playbooks/roles/ginas.gitlab_ci/tasks/main.yml
+++ b/playbooks/roles/ginas.gitlab_ci/tasks/main.yml
@@ -4,7 +4,7 @@
   apt: pkg={{ item }} state=latest install_recommends=no
   with_items: [ 'build-essential', 'libxml2-dev', 'libxslt1-dev', 'libcurl4-openssl-dev',
                 'libreadline6-dev', 'libc6-dev', 'libssl-dev', 'make', 'zlib1g-dev',
-                'libyaml-dev', 'libicu-dev', 'redis-server' ]
+                'libyaml-dev', 'libicu-dev' ]
 
 - name: Install required MySQL database packages
   apt: pkg={{ item }} state=latest install_recommends=no


### PR DESCRIPTION
Rather than use the default version of redis let's use our redis role instead.
