### PR TITLE
Remove monit from common roles

### DIFF
--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -28,7 +28,6 @@
     - { role: ginas.pki, tags: pki }
     - { role: ginas.apt, tags: apt }
     - { role: ginas.ferm, tags: ferm }
-    - { role: ginas.monit, tags: monit }
     - { role: ginas.ntp, tags: ntp }
     - { role: ginas.monkeysphere, tags: monkeysphere }
     - { role: ginas.sshd, tags: sshd }

--- a/playbooks/roles/ginas.monit/README.md
+++ b/playbooks/roles/ginas.monit/README.md
@@ -24,6 +24,13 @@ dependencies:
     tags: monit
 ```
 
+#### inventory/hosts
+
+```
+[ginas_monit]
+somehost
+```
+
 #### inventory/host_vars/somehost.yml
 
 ```

--- a/playbooks/roles/ginas.monit/defaults/main.yml
+++ b/playbooks/roles/ginas.monit/defaults/main.yml
@@ -1,8 +1,5 @@
 # --- Globals ---
 
-# Should monit be enabled?
-monit: True
-
 # The number of seconds to determine if a process is down or not.
 monit_interval: 60
 

--- a/playbooks/roles/ginas.monit/tasks/main.yml
+++ b/playbooks/roles/ginas.monit/tasks/main.yml
@@ -33,8 +33,3 @@
 
 - name: Start Monit
   service: name=monit state=started enabled=yes
-  when: monit
-
-- name: Stop Monit
-  service: name=monit state=stopped enabled=no
-  when: not monit

--- a/playbooks/services.yml
+++ b/playbooks/services.yml
@@ -54,6 +54,15 @@
     - { role: ginas.samba, tags: samba }
 
 
+# Monit
+- name: Monit support
+  hosts: ginas_monit
+  sudo: yes
+
+  roles:
+    - { role: ginas.monit, tags: monit }
+
+
 # MySQL database server
 - name: MySQL support
   hosts: ginas_mysql


### PR DESCRIPTION
Rather than add monit to the common roles, let's put it into services that users can opt into.
