### PR TITLE
Cap the total redis RAM usage with a multiplier

### DIFF
--- a/playbooks/roles/ginas.redis/defaults/main.yml
+++ b/playbooks/roles/ginas.redis/defaults/main.yml
@@ -100,7 +100,11 @@ redis_requirepass: False
 # --- Limits ---
 
 redis_maxclients: 10000
-redis_maxmemory: '{{ ansible_memtotal_mb }}mb'
+
+# Set a percent multiplier to cap the amount of RAM redis will use. For example
+# if you wanted to limit it to 80% of the total RAM you would input 0.8.
+redis_maxmemory_multiplier: 1.0
+
 redis_maxmemory_policy: 'volatile-lru'
 
 

--- a/playbooks/roles/ginas.redis/tasks/server.yml
+++ b/playbooks/roles/ginas.redis/tasks/server.yml
@@ -65,7 +65,7 @@
 
 - name: Insert templated values to the main Redis config
   lineinfile:
-    regexp: '^{{ item.key }} {{ item.value }}'
+    regexp: '^{{ item.key }}'
     dest: '{{ redis_config }}'
     line: '{{ item.key }} {{ item.value }}'
     insertafter: '^save'

--- a/playbooks/roles/ginas.redis/vars/main.yml
+++ b/playbooks/roles/ginas.redis/vars/main.yml
@@ -45,6 +45,7 @@ redis_repl_disable_tcp_nodelay: 'no'
 
 # --- Limits ---
 
+redis_maxmemory: '{{ (ansible_memtotal_mb | int * redis_maxmemory_multiplier) | round | int }}mb'
 redis_maxmemory_samples: 3
 
 


### PR DESCRIPTION
Allow you to cap the total memory usage with a percent based multiplier. Also fix a regex bug that tried to match on the exact value of a redis command instead of just the key.
