### PR TITLE
Use local timezone config in PHP5 role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,10 @@ based on a list of hosts in a specified group (`ginas_sks` by default).
 `ansible` role can now detect Redis installed on Ansible Controller and
 configure ansible to use host fact caching automatically.
 
+`php5` role will now use timezone of the remote host instead of Ansible
+Controller.
+
+
 ## July 2014
 
 ### New roles

--- a/playbooks/roles/ginas.php5/defaults/main.yml
+++ b/playbooks/roles/ginas.php5/defaults/main.yml
@@ -17,10 +17,6 @@ php5_upload_max_filesize: '{{ php5_post_max_size }}'
 php5_max_file_uploads: 20
 php5_allow_url_fopen: 'On'
 
-# Configure default PHP5 timezone (by default Ansible will try and use timezone
-# from Ansible Controller, if that is not available, it will be set to UTC)
-php5_date_timezone: ""
-
 # Default values used in pools when pool has none set
 php5_default_pm: 'ondemand'
 php5_default_pm_max_children: 5

--- a/playbooks/roles/ginas.php5/tasks/main.yml
+++ b/playbooks/roles/ginas.php5/tasks/main.yml
@@ -1,20 +1,9 @@
 ---
 
-- name: Check if /etc/timezone exists on Ansible Controller
-  local_action: stat path=/etc/timezone
-  sudo: no
+- name: Get current timezone from the host
+  slurp:
+    src: '/etc/timezone'
   register: php5_etc_timezone
-
-- name: Configure default timezone based on Ansible Controller
-  set_fact:
-    php5_date_timezone: '{{ lookup("file","/etc/timezone") }}'
-  when: (php5_date_timezone is undefined or not php5_date_timezone) and
-        (php5_etc_timezone is defined and php5_etc_timezone.stat.exists == True)
-
-- name: Configure default timezone if not defined
-  set_fact:
-    php5_date_timezone: 'UTC'
-  when: php5_date_timezone is undefined or not php5_date_timezone
 
 - name: Make sure PHP5-FPM support is installed
   apt: pkg={{ item }} state=latest install_recommends=no

--- a/playbooks/roles/ginas.php5/templates/etc/php5/fpm/php.ini.j2
+++ b/playbooks/roles/ginas.php5/templates/etc/php5/fpm/php.ini.j2
@@ -896,7 +896,7 @@ cli_server.color = On
 {#
 ; Defines the default timezone used by the date functions
 ; http://php.net/date.timezone #}
-date.timezone = {{ php5_date_timezone }}
+date.timezone = {{ php5_etc_timezone.content | b64decode | trim }}
 {#
 ; http://php.net/date.default-latitude
 ;date.default_latitude = 31.7667


### PR DESCRIPTION
Previously timezone configuration was read from the Ansible Controller,
which could be in an entirely different timezone. Now, 'php5' role will
read timezone configuration from the remote host itself.
