### PR TITLE
Add OpenSSL and curl in default LXC template

### DIFF
--- a/playbooks/roles/debops.lxc/defaults/main.yml
+++ b/playbooks/roles/debops.lxc/defaults/main.yml
@@ -110,7 +110,8 @@ lxc_template_debootstrap_packages: [ 'ifupdown', 'locales', 'libui-dialog-perl',
                                      'openssh-server', 'sudo', 'lsb-release', 'python',
                                      'python-apt', 'python-pycurl', 'make', 'git',
                                      'ncurses-term', 'iputils-ping', 'debian-archive-keyring',
-                                     'apt-transport-https', 'vim-tiny', 'cron' ]
+                                     'apt-transport-https', 'vim-tiny', 'cron', 'curl',
+                                     'openssl', 'ca-certificates' ]
 
 
 # ---- Manage LXC containers ----


### PR DESCRIPTION
This will make default LXC containers support HTTPS connections from the
start.
